### PR TITLE
proxy: sanitize headers and normalize paths before upstream

### DIFF
--- a/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
+++ b/cmd/kube-rbac-proxy/app/kube-rbac-proxy.go
@@ -283,9 +283,16 @@ func Run(cfg *completedProxyRunOptions) error {
 	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cleaned := path.Clean(req.URL.Path)
+		if cleaned != req.URL.Path {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
 		ignorePathFound := false
 		for _, pathIgnored := range cfg.ignorePaths {
-			ignorePathFound, err = path.Match(pathIgnored, req.URL.Path)
+			var err error
+			ignorePathFound, err = path.Match(pathIgnored, cleaned)
 			if err != nil {
 				http.Error(
 					w,
@@ -309,6 +316,14 @@ func Run(cfg *completedProxyRunOptions) error {
 			return
 		}
 
+		req.Header.Del("Authorization")
+		req.Header.Del(cfg.auth.Authentication.Header.UserFieldName)
+		req.Header.Del(cfg.auth.Authentication.Header.GroupsFieldName)
+		for key := range req.Header {
+			if strings.HasPrefix(strings.ToLower(key), "x-remote-extra-") {
+				req.Header.Del(key)
+			}
+		}
 		proxy.ServeHTTP(w, req)
 	})
 	handler = filters.WithAllowPaths(cfg.allowPaths, handler)

--- a/pkg/filters/auth.go
+++ b/pkg/filters/auth.go
@@ -107,17 +107,20 @@ func WithAuthorization(
 // WithAuthHeaders adds identity information to the headers.
 // Must not be used, if connection is not encrypted with TLS.
 func WithAuthHeaders(cfg *authn.AuthnHeaderConfig, handler http.HandlerFunc) http.HandlerFunc {
-	if !cfg.Enabled {
-		return handler
-	}
-
 	return func(w http.ResponseWriter, req *http.Request) {
-		u, ok := request.UserFrom(req.Context())
-		if ok {
-			// Seemingly well-known headers to tell the upstream about user's identity
-			// so that the upstream can achieve the original goal of delegating RBAC authn/authz to kube-rbac-proxy
-			req.Header.Set(cfg.UserFieldName, u.GetName())
-			req.Header.Set(cfg.GroupsFieldName, strings.Join(u.GetGroups(), cfg.GroupSeparator))
+		req.Header.Del(cfg.UserFieldName)
+		req.Header.Del(cfg.GroupsFieldName)
+		for key := range req.Header {
+			if strings.HasPrefix(strings.ToLower(key), "x-remote-extra-") {
+				req.Header.Del(key)
+			}
+		}
+
+		if cfg.Enabled {
+			if u, ok := request.UserFrom(req.Context()); ok {
+				req.Header.Set(cfg.UserFieldName, u.GetName())
+				req.Header.Set(cfg.GroupsFieldName, strings.Join(u.GetGroups(), cfg.GroupSeparator))
+			}
 		}
 
 		handler.ServeHTTP(w, req)

--- a/pkg/filters/auth_test.go
+++ b/pkg/filters/auth_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 
@@ -392,4 +393,142 @@ type testCase struct {
 	given
 	expected
 	description string
+}
+
+func TestWithAuthHeadersStripsInboundWhenDisabled(t *testing.T) {
+	cfg := &authn.AuthnHeaderConfig{
+		Enabled:         false,
+		UserFieldName:   "X-Remote-User",
+		GroupsFieldName: "X-Remote-Groups",
+	}
+
+	var gotUser, gotGroups string
+	inner := func(w http.ResponseWriter, r *http.Request) {
+		gotUser = r.Header.Get("X-Remote-User")
+		gotGroups = r.Header.Get("X-Remote-Groups")
+	}
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.Header.Set("X-Remote-User", "spoofed-admin")
+	req.Header.Set("X-Remote-Groups", "system:masters")
+
+	rec := httptest.NewRecorder()
+	filters.WithAuthHeaders(cfg, inner).ServeHTTP(rec, req)
+
+	if gotUser != "" {
+		t.Errorf("inbound X-Remote-User not stripped when auth-headers disabled: got %q", gotUser)
+	}
+	if gotGroups != "" {
+		t.Errorf("inbound X-Remote-Groups not stripped when auth-headers disabled: got %q", gotGroups)
+	}
+}
+
+func TestWithAuthHeadersStripsExtraHeaders(t *testing.T) {
+	cfg := &authn.AuthnHeaderConfig{
+		Enabled:         true,
+		UserFieldName:   "X-Remote-User",
+		GroupsFieldName: "X-Remote-Groups",
+	}
+
+	var gotExtra string
+	inner := func(w http.ResponseWriter, r *http.Request) {
+		gotExtra = r.Header.Get("X-Remote-Extra-Scopes")
+	}
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.Header.Set("X-Remote-Extra-Scopes", "admin:full")
+
+	rec := httptest.NewRecorder()
+	filters.WithAuthHeaders(cfg, inner).ServeHTTP(rec, req)
+
+	if gotExtra != "" {
+		t.Errorf("inbound X-Remote-Extra-Scopes not stripped: got %q", gotExtra)
+	}
+}
+
+func TestIgnorePathStripsAuthorizationHeader(t *testing.T) {
+	var upstreamAuthHeader string
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamAuthHeader = r.Header.Get("Authorization")
+	})
+
+	handler := buildIgnorePathHandler([]string{"/healthz"}, &authn.AuthnHeaderConfig{
+		UserFieldName:   "X-Remote-User",
+		GroupsFieldName: "X-Remote-Groups",
+	}, upstream)
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	req.Header.Set("Authorization", "Bearer sa-token-prometheus-k8s")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if upstreamAuthHeader != "" {
+		t.Errorf("Authorization header forwarded to upstream on ignore-path: got %q, want empty", upstreamAuthHeader)
+	}
+}
+
+func TestIgnorePathStripsIdentityHeaders(t *testing.T) {
+	var gotUser, gotGroups string
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser = r.Header.Get("X-Remote-User")
+		gotGroups = r.Header.Get("X-Remote-Groups")
+	})
+
+	handler := buildIgnorePathHandler([]string{"/healthz"}, &authn.AuthnHeaderConfig{
+		UserFieldName:   "X-Remote-User",
+		GroupsFieldName: "X-Remote-Groups",
+	}, upstream)
+
+	req := httptest.NewRequest("GET", "/healthz", nil)
+	req.Header.Set("X-Remote-User", "system:admin")
+	req.Header.Set("X-Remote-Groups", "system:masters")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if gotUser != "" {
+		t.Errorf("X-Remote-User forwarded to upstream on ignore-path: got %q", gotUser)
+	}
+	if gotGroups != "" {
+		t.Errorf("X-Remote-Groups forwarded to upstream on ignore-path: got %q", gotGroups)
+	}
+}
+
+// buildIgnorePathHandler replicates the ignore-path handler logic from
+// kube-rbac-proxy.go for isolated testing of header sanitization.
+func buildIgnorePathHandler(ignorePaths []string, headerCfg *authn.AuthnHeaderConfig, upstream http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cleaned := path.Clean(req.URL.Path)
+		if cleaned != req.URL.Path {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		ignorePathFound := false
+		for _, pathIgnored := range ignorePaths {
+			found, err := path.Match(pathIgnored, cleaned)
+			if err != nil {
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+			if found {
+				ignorePathFound = true
+				break
+			}
+		}
+
+		if !ignorePathFound {
+			http.NotFound(w, req)
+			return
+		}
+
+		req.Header.Del("Authorization")
+		req.Header.Del(headerCfg.UserFieldName)
+		req.Header.Del(headerCfg.GroupsFieldName)
+		for key := range req.Header {
+			if strings.HasPrefix(strings.ToLower(key), "x-remote-extra-") {
+				req.Header.Del(key)
+			}
+		}
+		upstream.ServeHTTP(w, req)
+	})
 }

--- a/pkg/filters/path.go
+++ b/pkg/filters/path.go
@@ -26,8 +26,14 @@ func WithAllowPaths(allowPaths []string, handler http.HandlerFunc) http.HandlerF
 	}
 
 	return func(w http.ResponseWriter, req *http.Request) {
+		cleaned := path.Clean(req.URL.Path)
+		if cleaned != req.URL.Path {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
 		for _, pathAllowed := range allowPaths {
-			found, err := path.Match(pathAllowed, req.URL.Path)
+			found, err := path.Match(pathAllowed, cleaned)
 			if err != nil {
 				http.Error(
 					w,

--- a/pkg/filters/path_test.go
+++ b/pkg/filters/path_test.go
@@ -18,6 +18,7 @@ package filters_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"testing"
 
 	"github.com/brancz/kube-rbac-proxy/pkg/filters"
@@ -69,5 +70,57 @@ func TestAllowPath(t *testing.T) {
 				t.Errorf("want: %d\nhave: %d\n", tt.status, res.StatusCode)
 			}
 		})
+	}
+}
+
+func TestAllowPathRejectsNonCanonicalPath(t *testing.T) {
+	handler := filters.WithAllowPaths([]string{"/public/*"}, emptyHandler)
+
+	req := httptest.NewRequest("GET", "/public/..", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Errorf("non-canonical path /public/.. was not rejected: got status %d, want 400", rec.Code)
+	}
+}
+
+func TestIgnorePathRejectsNonCanonicalPath(t *testing.T) {
+	var upstreamCalled bool
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+	})
+
+	ignorePaths := []string{"/public/*"}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		cleaned := path.Clean(req.URL.Path)
+		if cleaned != req.URL.Path {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+
+		for _, pathIgnored := range ignorePaths {
+			found, err := path.Match(pathIgnored, cleaned)
+			if err != nil {
+				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				return
+			}
+			if found {
+				upstream.ServeHTTP(w, req)
+				return
+			}
+		}
+		http.NotFound(w, req)
+	})
+
+	req := httptest.NewRequest("GET", "/public/..", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if upstreamCalled {
+		t.Error("non-canonical path /public/.. reached upstream via ignore-paths")
+	}
+	if rec.Code == http.StatusOK {
+		t.Errorf("non-canonical path /public/.. was not rejected: got status %d, want 400", rec.Code)
 	}
 }


### PR DESCRIPTION
Strip Authorization and identity headers (X-Remote-User, X-Remote-Groups, X-Remote-Extra-*) from requests before forwarding to the upstream on the ignore-paths branch. The upstream process has no legitimate need for caller credentials on unauthenticated paths such as health checks.

Ensure WithAuthHeaders always strips inbound identity headers regardless of whether --auth-header-fields-enabled is set. When enabled, the proxy sets these from the authenticated user context; when disabled, they should not pass through from the caller. Identity headers reaching the upstream must be proxy-authoritative.

Normalize URL paths via path.Clean before matching against --ignore-paths and --allow-paths patterns. Reject non-canonical paths (containing .., //, trailing slashes) with 400 Bad Request to ensure consistent matching behavior.