### PR TITLE
Strip debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,16 @@ all: check-license build generate test
 GO111MODULE=on
 export GO111MODULE
 
+# Set DBG=1 to build without stripping debug symbols. Default produces a
+# stripped binary.
+DBG ?=
+
+ifeq ($(DBG),1)
+GOLDFLAGS ?=
+else
+GOLDFLAGS ?= -s -w
+endif
+
 PROGRAM_NAME?=kube-rbac-proxy
 # This repository moved to github.com/kube-rbac-proxy/kube-rbac-proxy.
 # Keep the old module path until the 1.0 release, where this is subject to change.
@@ -45,7 +55,7 @@ $(OUT_DIR)/$(PROGRAM_NAME)-%:
 	GOARCH=$(word 2,$(subst -, ,$(*:.exe=))) \
 	GOOS=$(word 1,$(subst -, ,$(*:.exe=))) \
 	CGO_ENABLED=0 \
-	go build --installsuffix cgo -ldflags="-X k8s.io/component-base/version.gitVersion=$(VERSION_SEMVER) -X k8s.io/component-base/version.gitCommit=$(shell git rev-parse HEAD) -X k8s.io/component-base/version/verflag.programName=$(PROGRAM_NAME)" -o $(OUT_DIR)/$(PROGRAM_NAME)-$* $(GITHUB_URL)/cmd/kube-rbac-proxy
+	go build --installsuffix cgo -ldflags="$(GOLDFLAGS) -X k8s.io/component-base/version.gitVersion=$(VERSION_SEMVER) -X k8s.io/component-base/version.gitCommit=$(shell git rev-parse HEAD) -X k8s.io/component-base/version/verflag.programName=$(PROGRAM_NAME)" -o $(OUT_DIR)/$(PROGRAM_NAME)-$* $(GITHUB_URL)/cmd/kube-rbac-proxy
 
 clean:
 	-rm -r $(OUT_DIR)


### PR DESCRIPTION
Follows DBG=1 pattern from kubernetes/kubernetes to produce an unstripped binary for debugging.

Reduces the binary size by approximately 32% when built with go1.26.5. 

Unstripped (DBG=1):
-rwxr-xr-x. 1 sdodson sdodson 77136200 Jul 15 13:19 kube-rbac-proxy-linux-amd64

Stripped:
-rwxr-xr-x. 1 sdodson sdodson 52355234 Jul 15 13:18 kube-rbac-proxy-linux-amd64

**Update:** addressed review feedback (https://github.com/kube-rbac-proxy/kube-rbac-proxy/pull/447/changes#r4027328789) by renaming the internal strip flags to `STRIP_LDFLAGS` so a user-supplied `GOLDFLAGS` is combined with them instead of being overwritten (e.g. `make build GOLDFLAGS="-v"` now works), and added `DBG_GCFLAGS` (`all=-N -l`) to disable optimizations/inlining when `DBG=1`, for a better debugging experience.